### PR TITLE
Update to hifi-audio-nodes 1.0.5

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -444,7 +444,9 @@ function deleteAudioContext() {
 
     hrtfOutput.disconnect(limiter);
     limiter.disconnect(audioContext.destination);
+    hrtfOutput.destroy();
     hrtfOutput = null;
+    limiter.destroy();
     limiter = null;
 
     HiFiAudioNodes.shutdownHRTF();
@@ -485,6 +487,7 @@ function onUserUnpublished(user) {
     if (hrtfInputs.has(user.uid)) {
         const hrtfInput = hrtfInputs.get(user.uid);
         hrtfInput.disconnect(hrtfOutput);
+        hrtfInput.destroy();
         hrtfInputs.delete(user.uid);
     }
     console.log('Remote user', user.uid, 'left the channel');
@@ -574,6 +577,7 @@ function deleteAudioContext() {
     noiseSuppression.disconnect(gatedNode);
     microphoneStream = null;
     microphoneNode = null;
+    noiseSuppression.destroy();
     noiseSuppression = null;
     gatedNode = null;
 
@@ -808,6 +812,7 @@ function deleteAudioContext() {
     ...
 
     localHrtfInput.disconnect(hrtfOutput);
+    localHrtfInput.destroy();
     localHrtfInput = null;
 
     hrtfOutput.disconnect(limiter);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "agora-rtc-sdk-ng": "^4.17.2",
                 "express": "^4.18.2",
-                "hifi-audio-nodes": "1.0.4"
+                "hifi-audio-nodes": "1.0.5"
             },
             "devDependencies": {
                 "eslint": "^8.37.0"
@@ -941,9 +941,9 @@
             }
         },
         "node_modules/hifi-audio-nodes": {
-            "version": "1.0.4",
-            "resolved": "https://npm.highfidelity.com/hifi-audio-nodes/-/hifi-audio-nodes-1.0.4.tgz",
-            "integrity": "sha512-1Ld43dW6KIIPR2VTfjrlfWiwGW6ZrrjrVMg+bikYuyx0bixD4WXum2t3mU0GyjGpEwkwB6qU6PGCJTS8YRIWow=="
+            "version": "1.0.5",
+            "resolved": "https://npm.highfidelity.com/hifi-audio-nodes/-/hifi-audio-nodes-1.0.5.tgz",
+            "integrity": "sha512-QL+OXEZKh8IkbsbvuP2o/yJNj45hih4jJGWShy4/MrYqUweIUZY027Suuk4nkyZ4h5+R/nODT0lJXU+pSATwpg=="
         },
         "node_modules/http-errors": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "agora-rtc-sdk-ng": "^4.17.2",
         "express": "^4.18.2",
-        "hifi-audio-nodes": "1.0.4"
+        "hifi-audio-nodes": "1.0.5"
     },
     "devDependencies": {
         "eslint": "^8.37.0"

--- a/tutorial/tutorial.js
+++ b/tutorial/tutorial.js
@@ -96,15 +96,19 @@ function deleteAudioContext() {
     noiseSuppression.disconnect(gatedNode);
     microphoneStream = null;
     microphoneNode = null;
+    noiseSuppression.destroy();
     noiseSuppression = null;
     gatedNode = null;
 
     localHrtfInput.disconnect(hrtfOutput);
+    localHrtfInput.destroy();
     localHrtfInput = null;
 
     hrtfOutput.disconnect(limiter);
     limiter.disconnect(audioContext.destination);
+    hrtfOutput.destroy();
     hrtfOutput = null;
+    limiter.destroy();
     limiter = null;
 
     HiFiAudioNodes.shutdownHRTF();
@@ -215,6 +219,7 @@ function onUserUnpublished(user) {
     if (hrtfInputs.has(user.uid)) {
         const hrtfInput = hrtfInputs.get(user.uid);
         hrtfInput.disconnect(hrtfOutput);
+        hrtfInput.destroy();
         hrtfInputs.delete(user.uid);
     }
     console.log('Remote user', user.uid, 'left the channel');


### PR DESCRIPTION
Update to the latest Nodes library version and use its new `destroy()` methods.